### PR TITLE
add shared layout for all pages and nested routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,14 +3,17 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Home from "./components/homepage/Home";
 import SearchPage from "./components/mainSearch/SearchPage";
 import AboutPage from "./components/poke-info/AboutPage";
+import SharedLayout from "./SharedLayout";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/database" element={<SearchPage />} />
-        <Route path="/about" element={<AboutPage />} />
+        <Route path="/" element={<SharedLayout />}>
+          <Route index element={<Home />} />
+          <Route path="/database" element={<SearchPage />} />
+          <Route path="/about" element={<AboutPage />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/SharedLayout.jsx
+++ b/src/SharedLayout.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Link, Outlet } from "react-router-dom";
+import Navbar from "./components/navbar/Navbar";
+
+const SharedLayout = () => {
+  return (
+    <>
+      <Navbar />
+      <div className="page-container">
+        <Outlet />
+      </div>
+    </>
+  );
+};
+
+export default SharedLayout;

--- a/src/components/mainSearch/SearchPage.jsx
+++ b/src/components/mainSearch/SearchPage.jsx
@@ -5,7 +5,6 @@ import MainSearch from "./MainSearch";
 const SearchPage = () => {
   return (
     <>
-      <Navbar />
       <MainSearch />
     </>
   );

--- a/src/components/poke-info/AboutPage.jsx
+++ b/src/components/poke-info/AboutPage.jsx
@@ -7,7 +7,6 @@ import TeamSection from "./TeamSection";
 const AboutPage = () => {
   return (
     <>
-      <Navbar />
       <AboutHeading />
       <TeamSection />
       <BuildInfo />


### PR DESCRIPTION
So considering that each page had a similar layout, I decided to create a "shared layout" component. This required nested routing for handling routing throughout the site. Essentially, there is no visual change to the site, but there is an improvement because the navigation bar no longer needs to be rendered or passed in each page component.  